### PR TITLE
IOS - confirmation modal for star rating and dashboard announcement view

### DIFF
--- a/src/components/pages/Classroom/ClassroomList/index.tsx
+++ b/src/components/pages/Classroom/ClassroomList/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 import { BoldText } from '~reusables/ui/Text';
 import CustomField from '~reusables/CustomField';

--- a/src/components/pages/Dashboard/Hero/index.tsx
+++ b/src/components/pages/Dashboard/Hero/index.tsx
@@ -1,43 +1,61 @@
+import { useState } from 'react';
 import { Heading1 } from '~reusables/ui/Heading';
 import { BaseText } from '~reusables/ui/Text';
 import { ActionBtn } from '~reusables/ui/Buttons';
 import { Card } from '~reusables/ui/Others';
-import 'react-alice-carousel/lib/alice-carousel.css';
 import Carousel from '~reusables/Carousel';
+import ViewAnnouncementModal from '~components/pages/Announcements/View';
 
-const Hero = () => (
-  <div className="mt-8">
-    <Carousel>
-      <div className="item">
-        <Card className="bg-purple.light p-6 ">
-          <Heading1 className="truncate">Examination Information</Heading1>
-          <BaseText className="mt-4 mb-2imp text-gray-500  truncate">
-            Exam commences on the 31st of June, 2024
-          </BaseText>
-          <ActionBtn className="mt-4 px-4 py-2">Read more</ActionBtn>
-        </Card>
-      </div>
-      <div className="item">
-        <Card className="bg-purple.light p-6 ">
-          <Heading1 className="truncate">Next PTA meeting</Heading1>
-          <BaseText className="mt-4 mb-2imp text-gray-500  truncate">
-            Our PTA meeting comes up on the 31st of August, 2024. Guardians are
-            advised to be present
-          </BaseText>
-          <ActionBtn className="mt-4 px-4 py-2">Read more</ActionBtn>
-        </Card>
-      </div>
-      <div className="item">
-        <Card className="bg-purple.light p-6 ">
-          <Heading1 className="truncate">End of Term</Heading1>
-          <BaseText className="mt-4 mb-2imp text-gray-500  truncate">
-            The current term ends on the 15th of August, 2024
-          </BaseText>
-          <ActionBtn className="mt-4 px-4 py-2">Read more</ActionBtn>
-        </Card>
-      </div>
-    </Carousel>
-  </div>
-);
+const Hero = () => {
+  const [announcement, setAnnouncement] = useState('');
+
+  const renderAnnouncement = () => setAnnouncement('new announcement');
+  return (
+    <div className="mt-8">
+      {announcement && (
+        <ViewAnnouncementModal
+          view={announcement}
+          closeModal={() => setAnnouncement('')}
+        />
+      )}
+      <Carousel>
+        <div className="item">
+          <Card className="bg-purple.light p-6 ">
+            <Heading1 className="truncate">Examination Information</Heading1>
+            <BaseText className="mt-4 mb-2imp text-gray-500 truncate">
+              Exam commences on the 31st of June, 2024
+            </BaseText>
+            <ActionBtn onClick={renderAnnouncement} className="mt-4 px-4 py-2">
+              Read more
+            </ActionBtn>
+          </Card>
+        </div>
+        <div className="item">
+          <Card className="bg-purple.light p-6 ">
+            <Heading1 className="truncate">Next PTA meeting</Heading1>
+            <BaseText className="mt-4 mb-2imp text-gray-500 truncate">
+              Our PTA meeting comes up on the 31st of August, 2024. Guardians
+              are advised to be present
+            </BaseText>
+            <ActionBtn onClick={renderAnnouncement} className="mt-4 px-4 py-2">
+              Read more
+            </ActionBtn>
+          </Card>
+        </div>
+        <div className="item">
+          <Card className="bg-purple.light p-6 ">
+            <Heading1 className="truncate">End of Term</Heading1>
+            <BaseText className="mt-4 mb-2imp text-gray-500 truncate">
+              The current term ends on the 15th of August, 2024
+            </BaseText>
+            <ActionBtn onClick={renderAnnouncement} className="mt-4 px-4 py-2">
+              Read more
+            </ActionBtn>
+          </Card>
+        </div>
+      </Carousel>
+    </div>
+  );
+};
 
 export default Hero;

--- a/src/components/pages/Students/Detail/List/index.tsx
+++ b/src/components/pages/Students/Detail/List/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 
 const SubjectList = () => (

--- a/src/components/pages/Subjects/Detail/List/index.tsx
+++ b/src/components/pages/Subjects/Detail/List/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 
 const SubjectList = () => (

--- a/src/components/pages/Teachers/Detail/List/index.tsx
+++ b/src/components/pages/Teachers/Detail/List/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 
 const SubjectList = () => (

--- a/src/components/reusables/Modal/index.tsx
+++ b/src/components/reusables/Modal/index.tsx
@@ -22,9 +22,9 @@ type TModal = {
 };
 
 const sizes = {
-  sm: 'md:min-w-[40%] lg:min-w-[25%] lg:max-w-[30vw] xl:max-w-[400px]',
-  md: 'md:min-w-[60%] lg:min-w-[40%] md:max-w-[60vw] lg:max-w-[40vw] xl:max-w-[700px]',
-  lg: 'md:min-w-[80%] lg:min-w-[60%]',
+  sm: 'sm:min-w-[50%] lg:min-w-[30%] lg:max-w-[30vw] xl:max-w-[400px]',
+  md: 'sm:min-w-[65%] lg:min-w-[40%] md:max-w-[60vw] lg:max-w-[40vw] xl:max-w-[700px]',
+  lg: 'sm:min-w-[90%] lg:min-w-[60%]',
 };
 
 const Modal: FC<TModal> = ({
@@ -52,7 +52,7 @@ const Modal: FC<TModal> = ({
     <div
       ref={modal}
       onClick={(e) => e.target === modal.current && close((prev) => !prev)}
-      className="fixed text-left transition-all flex justify-center md:items-center bg-[#918e8eb3] top-0 left-0 h-screen w-screen z-50 p-8"
+      className="fixed text-left transition-all flex justify-center md:items-center bg-[#a4a3a3d3] top-0 left-0 h-screen w-screen z-50 p-8"
     >
       <div
         className={`transition-all relative min-w-[280px] flex flex-col h-fit max-h-[80vh] sm:max-h-[90vh] ${

--- a/src/components/reusables/RateSomeone/ConfirmRatingModal/index.tsx
+++ b/src/components/reusables/RateSomeone/ConfirmRatingModal/index.tsx
@@ -1,0 +1,19 @@
+import { memo } from 'react';
+import Modal from '~components/reusables/Modal';
+
+type TConfirmRatingModal = {
+  closeModal: () => void;
+  rating: number;
+};
+
+const ConfirmRatingModal = ({ closeModal, rating }: TConfirmRatingModal) => (
+  <Modal
+    size="sm"
+    title={`Confirm ${rating} Star${rating > 1 ? 's' : ''} Rating?`}
+    action={() => null}
+    close={() => closeModal()}
+    actionText="Confirm"
+  />
+);
+
+export default memo(ConfirmRatingModal);

--- a/src/components/reusables/RateSomeone/index.tsx
+++ b/src/components/reusables/RateSomeone/index.tsx
@@ -4,6 +4,7 @@ import useGetCountriesAndState from '../hooks/useGetCountriesAndState';
 import CustomField from '~reusables/CustomField';
 import useCustomField from '~reusables/CustomField/hooks-custom-field/useCustomField';
 import StarRatings from '~reusables/StarRating';
+import ConfirmRatingModal from './ConfirmRatingModal';
 
 const RateSomeone = () => {
   const { countries, isLoading: fetchingCountry } = useGetCountriesAndState();
@@ -22,8 +23,15 @@ const RateSomeone = () => {
     setRating(i);
   };
 
+  const closeModal = () => {
+    setRating(0);
+  };
+
   return (
     <>
+      {!!rating && (
+        <ConfirmRatingModal rating={rating} closeModal={closeModal} />
+      )}
       <BoldText>Rate Someone</BoldText>
       <div className="flex justify-between flex-wrap gap-4 gap-y-3 mt-3">
         <div className="grow xs-grow-0 w-[180px]">


### PR DESCRIPTION
# Why this PR?
Render a confirmation modal when a user is rated  and open the announcement from the slider in the dashboard



# What does this PR do?
- Added a confirmation modal for a star rating
- Implemented dashboard announcement view
- 
# How to test your work?
- In the dashboard page, click on one of the "read more" button in the slider it should trigger the modal to open
- rate someone, and the confirmation modal should open

# Pages to see your changes?
- /dashboard
