### PR TITLE
Ios announcement modal on dashboard

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      VITE_BASE_URL: ${{ secrets.VITE_BASE_URL }}
+      VITE_COUNTRIES_URL: ${{ secrets.VITE_COUNTRIES_URL }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/src/api/announcements-api.ts
+++ b/src/api/announcements-api.ts
@@ -1,0 +1,11 @@
+import { AxiosInstance } from 'axios';
+import { TAnnouncementsData } from '~shared-ts-types/t-announcements-data';
+
+export default (api: AxiosInstance) => ({
+  getAllAnnouncements: async (): Promise<{
+    data: TAnnouncementsData[];
+  }> => {
+    const res = await api.get('/announcements');
+    return res.data;
+  },
+});

--- a/src/api/external-api.ts
+++ b/src/api/external-api.ts
@@ -10,5 +10,4 @@ export default (api: AxiosInstance) => ({
     const res = await api.get(COUNTRY_URL);
     return res.data;
   },
-  girl: () => null,
 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,12 +1,19 @@
 import axios, { AxiosInstance } from 'axios';
-import externalApi from './externalApi';
+import externalApi from './external-api';
+import announcementsApi from './announcements-api';
+import TApi from '~shared-ts-types/t-api';
 
-type TApi = ReturnType<typeof externalApi>;
-
+const baseURL = String(import.meta.env.VITE_BASE_URL);
 class Api {
-  private axiosInstance: AxiosInstance = axios.create({});
+  private axiosInstance: AxiosInstance = axios.create({
+    baseURL,
+    responseType: 'json',
+  });
 
-  api: TApi = { ...externalApi(this.axiosInstance) };
+  api: TApi = {
+    ...externalApi(this.axiosInstance),
+    ...announcementsApi(this.axiosInstance),
+  };
 }
 
 export default Api;

--- a/src/components/pages/Announcements/index.tsx
+++ b/src/components/pages/Announcements/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import AsideAdmin from '~components/Layout/AsideAdmin';
 import { BaseBtn } from '~reusables/ui/Buttons';
 import Icon from '~assets/Icons';
@@ -7,10 +8,20 @@ import FilterAnnouncements from './Filter';
 import { formatDate } from '~utils/format';
 import ViewAnnouncement from './View';
 import ListOptions from '~components/reusables/ListOptions';
+import Api from '~api';
+
+const { api } = new Api();
 
 const Announcements = () => {
   const [modal, setModal] = useState('');
   const [view, setView] = useState('');
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['ANNOUNCEMENTS'],
+    queryFn: () => api.getAllAnnouncements(),
+  });
+
+  console.log(data, isLoading);
 
   return (
     <section

--- a/src/components/pages/Classroom/ClassroomList/index.tsx
+++ b/src/components/pages/Classroom/ClassroomList/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 import { BoldText } from '~reusables/ui/Text';
 import CustomField from '~reusables/CustomField';

--- a/src/components/pages/Dashboard/Hero/index.tsx
+++ b/src/components/pages/Dashboard/Hero/index.tsx
@@ -1,43 +1,61 @@
+import { useState } from 'react';
 import { Heading1 } from '~reusables/ui/Heading';
 import { BaseText } from '~reusables/ui/Text';
 import { ActionBtn } from '~reusables/ui/Buttons';
 import { Card } from '~reusables/ui/Others';
-import 'react-alice-carousel/lib/alice-carousel.css';
 import Carousel from '~reusables/Carousel';
+import ViewAnnouncementModal from '~components/pages/Announcements/View';
 
-const Hero = () => (
-  <div className="mt-8">
-    <Carousel>
-      <div className="item">
-        <Card className="bg-purple.light p-6 ">
-          <Heading1 className="truncate">Examination Information</Heading1>
-          <BaseText className="mt-4 mb-2imp text-gray-500  truncate">
-            Exam commences on the 31st of June, 2024
-          </BaseText>
-          <ActionBtn className="mt-4 px-4 py-2">Read more</ActionBtn>
-        </Card>
-      </div>
-      <div className="item">
-        <Card className="bg-purple.light p-6 ">
-          <Heading1 className="truncate">Next PTA meeting</Heading1>
-          <BaseText className="mt-4 mb-2imp text-gray-500  truncate">
-            Our PTA meeting comes up on the 31st of August, 2024. Guardians are
-            advised to be present
-          </BaseText>
-          <ActionBtn className="mt-4 px-4 py-2">Read more</ActionBtn>
-        </Card>
-      </div>
-      <div className="item">
-        <Card className="bg-purple.light p-6 ">
-          <Heading1 className="truncate">End of Term</Heading1>
-          <BaseText className="mt-4 mb-2imp text-gray-500  truncate">
-            The current term ends on the 15th of August, 2024
-          </BaseText>
-          <ActionBtn className="mt-4 px-4 py-2">Read more</ActionBtn>
-        </Card>
-      </div>
-    </Carousel>
-  </div>
-);
+const Hero = () => {
+  const [announcement, setAnnouncement] = useState('');
+
+  const renderAnnouncement = () => setAnnouncement('new announcement');
+  return (
+    <div className="mt-8">
+      {announcement && (
+        <ViewAnnouncementModal
+          view={announcement}
+          closeModal={() => setAnnouncement('')}
+        />
+      )}
+      <Carousel>
+        <div className="item">
+          <Card className="bg-purple.light p-6 ">
+            <Heading1 className="truncate">Examination Information</Heading1>
+            <BaseText className="mt-4 mb-2imp text-gray-500 truncate">
+              Exam commences on the 31st of June, 2024
+            </BaseText>
+            <ActionBtn onClick={renderAnnouncement} className="mt-4 px-4 py-2">
+              Read more
+            </ActionBtn>
+          </Card>
+        </div>
+        <div className="item">
+          <Card className="bg-purple.light p-6 ">
+            <Heading1 className="truncate">Next PTA meeting</Heading1>
+            <BaseText className="mt-4 mb-2imp text-gray-500 truncate">
+              Our PTA meeting comes up on the 31st of August, 2024. Guardians
+              are advised to be present
+            </BaseText>
+            <ActionBtn onClick={renderAnnouncement} className="mt-4 px-4 py-2">
+              Read more
+            </ActionBtn>
+          </Card>
+        </div>
+        <div className="item">
+          <Card className="bg-purple.light p-6 ">
+            <Heading1 className="truncate">End of Term</Heading1>
+            <BaseText className="mt-4 mb-2imp text-gray-500 truncate">
+              The current term ends on the 15th of August, 2024
+            </BaseText>
+            <ActionBtn onClick={renderAnnouncement} className="mt-4 px-4 py-2">
+              Read more
+            </ActionBtn>
+          </Card>
+        </div>
+      </Carousel>
+    </div>
+  );
+};
 
 export default Hero;

--- a/src/components/pages/Media/View/index.tsx
+++ b/src/components/pages/Media/View/index.tsx
@@ -10,7 +10,13 @@ const ViewMedia = ({ img, closeModal }: TViewMedia) => (
   <Modal
     size="md"
     scroll={false}
-    content={<img className="w-full h-auto" src={img} alt="imaging" />}
+    content={
+      <img
+        className=" mx-auto w-auto h-full object-contain"
+        src={img}
+        alt="imaging"
+      />
+    }
     close={() => closeModal()}
   />
 );

--- a/src/components/pages/Students/Detail/List/index.tsx
+++ b/src/components/pages/Students/Detail/List/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 
 const SubjectList = () => (

--- a/src/components/pages/Subjects/Detail/List/index.tsx
+++ b/src/components/pages/Subjects/Detail/List/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 
 const SubjectList = () => (

--- a/src/components/pages/Teachers/Detail/List/index.tsx
+++ b/src/components/pages/Teachers/Detail/List/index.tsx
@@ -1,4 +1,3 @@
-import 'react-alice-carousel/lib/alice-carousel.css';
 import { NavLink } from 'react-router-dom';
 
 const SubjectList = () => (

--- a/src/components/reusables/Modal/index.tsx
+++ b/src/components/reusables/Modal/index.tsx
@@ -22,9 +22,9 @@ type TModal = {
 };
 
 const sizes = {
-  sm: 'md:min-w-[40%] lg:min-w-[25%] lg:max-w-[30vw] xl:max-w-[400px]',
-  md: 'md:min-w-[60%] lg:min-w-[40%] md:max-w-[60vw] lg:max-w-[40vw] xl:max-w-[700px]',
-  lg: 'md:min-w-[80%] lg:min-w-[60%]',
+  sm: 'sm:min-w-[50%] lg:min-w-[30%] lg:max-w-[30vw] xl:max-w-[400px]',
+  md: 'sm:min-w-[65%] lg:min-w-[40%] md:max-w-[60vw] lg:max-w-[40vw] xl:max-w-[700px]',
+  lg: 'sm:min-w-[90%] lg:min-w-[60%]',
 };
 
 const Modal: FC<TModal> = ({
@@ -52,7 +52,7 @@ const Modal: FC<TModal> = ({
     <div
       ref={modal}
       onClick={(e) => e.target === modal.current && close((prev) => !prev)}
-      className="fixed text-left transition-all flex justify-center md:items-center bg-[#918e8eb3] top-0 left-0 h-screen w-screen z-50 p-8"
+      className="fixed text-left transition-all flex justify-center md:items-center bg-[#a4a3a3d3] top-0 left-0 h-screen w-screen z-50 p-8"
     >
       <div
         className={`transition-all relative min-w-[280px] flex flex-col h-fit max-h-[80vh] sm:max-h-[90vh] ${

--- a/src/components/reusables/RateSomeone/ConfirmRatingModal/index.tsx
+++ b/src/components/reusables/RateSomeone/ConfirmRatingModal/index.tsx
@@ -1,0 +1,19 @@
+import { memo } from 'react';
+import Modal from '~components/reusables/Modal';
+
+type TConfirmRatingModal = {
+  closeModal: () => void;
+  rating: number;
+};
+
+const ConfirmRatingModal = ({ closeModal, rating }: TConfirmRatingModal) => (
+  <Modal
+    size="sm"
+    title={`Confirm ${rating} Star${rating > 1 ? 's' : ''} Rating?`}
+    action={() => null}
+    close={() => closeModal()}
+    actionText="Confirm"
+  />
+);
+
+export default memo(ConfirmRatingModal);

--- a/src/components/reusables/RateSomeone/index.tsx
+++ b/src/components/reusables/RateSomeone/index.tsx
@@ -4,6 +4,7 @@ import useGetCountriesAndState from '../hooks/useGetCountriesAndState';
 import CustomField from '~reusables/CustomField';
 import useCustomField from '~reusables/CustomField/hooks-custom-field/useCustomField';
 import StarRatings from '~reusables/StarRating';
+import ConfirmRatingModal from './ConfirmRatingModal';
 
 const RateSomeone = () => {
   const { countries, isLoading: fetchingCountry } = useGetCountriesAndState();
@@ -22,8 +23,15 @@ const RateSomeone = () => {
     setRating(i);
   };
 
+  const closeModal = () => {
+    setRating(0);
+  };
+
   return (
     <>
+      {!!rating && (
+        <ConfirmRatingModal rating={rating} closeModal={closeModal} />
+      )}
       <BoldText>Rate Someone</BoldText>
       <div className="flex justify-between flex-wrap gap-4 gap-y-3 mt-3">
         <div className="grow xs-grow-0 w-[180px]">

--- a/src/shared-ts-types/t-announcements-data.ts
+++ b/src/shared-ts-types/t-announcements-data.ts
@@ -1,0 +1,36 @@
+type TRecipients = 'parents' | 'teachers' | 'students' | 'all';
+
+type TCommon = {
+  message: string;
+  recipient: TRecipients;
+  title: string;
+};
+
+export type TAnnouncementPayload = TCommon &
+  (
+    | {
+        event_end_date?: null;
+        event_start_date?: null;
+        event_time?: null;
+        type: 'memo';
+      }
+    | {
+        event_end_date: string;
+        event_start_date: string;
+        event_time?: null;
+        type: 'multi_event';
+      }
+    | {
+        event_end_date?: null;
+        event_start_date: string;
+        event_time: string;
+        type: 'single_event';
+      }
+  );
+
+type TFromApi = {
+  date_created: string;
+  id: 31;
+};
+
+export type TAnnouncementsData = TFromApi & TAnnouncementPayload;

--- a/src/shared-ts-types/t-api.ts
+++ b/src/shared-ts-types/t-api.ts
@@ -1,0 +1,7 @@
+import externalApi from '~src/api/external-api';
+import announcementsApi from '~src/api/announcements-api';
+
+type TApi = ReturnType<typeof externalApi> &
+  ReturnType<typeof announcementsApi>;
+
+export default TApi;


### PR DESCRIPTION
# Why this PR?
- The announcement modal needed to have certain functionalities based on the announcement type

# What does this PR do?
- Added the proper fields for multi_event, single_event and memo

# How to test your work?
- Go to the announcements page and try to add a new announcement

# Pages to see your changes?
- /announcements
