### PR TITLE
Ios reset signup details

### DIFF
--- a/src/components/pages/Announcements/widgets-announcements/FilterAnnouncements/index.tsx
+++ b/src/components/pages/Announcements/widgets-announcements/FilterAnnouncements/index.tsx
@@ -1,17 +1,35 @@
 import { memo, useState } from 'react';
 import DateTimePicker from 'react-datetime-picker';
 import { useLocation } from 'react-router-dom';
+import SelectField from '~components/reusables/CustomField/SelectField';
 import Modal from '~components/reusables/Modal';
 import CustomField from '~reusables/CustomField';
 import useCustomField from '~reusables/CustomField/hooks-custom-field/useCustomField';
 import { BoldText } from '~reusables/ui/Text';
 import { capCharRemoveUnderscore, dateToDbFormat } from '~utils/format';
 
-const nums = Array(365)
+const nums = Array(366)
   .fill('')
-  .map((_, i) => String(i));
+  .map((_, i) => i)
+  .slice(1);
 
 const types = ['memo', 'single_event', 'multi_event'];
+
+const announcementTypeDropdown = (val: string | number) => (
+  <div className="py-2">{capCharRemoveUnderscore(String(val))}</div>
+);
+
+const eventDaysDropdown = (val: string | number) => (
+  <div className="py-3">
+    {val} Day{+val > 1 && 's'}
+  </div>
+);
+
+const selectedEventDaysElement = (val: string | number) => (
+  <span>
+    {val} Day{+val > 1 && 's'}
+  </span>
+);
 
 type TFilterAnnouncement = {
   action: (arg: { [key: string]: string | number }) => void;
@@ -21,17 +39,14 @@ type TFilterAnnouncement = {
 const FilterAnnouncement = ({ closeModal, action }: TFilterAnnouncement) => {
   const state = useLocation().state ?? {};
   const [search, setSearch] = useCustomField<string>(state.search || '');
-  const [type, setType] = useCustomField<string>(state.announcement_type || '');
+  const [type, setType] = useState<string>(state.announcement_type || '');
   const [fromDate, setFromDate] = useState<Date | null>(
     state.from_date ? new Date(state.from_date) : null
   );
   const [toDate, setToDate] = useState<Date | null>(
     state.to_date ? new Date(state.to_date) : null
   );
-  const [days, setDays, daysList, daysListFilterFn] = useCustomField<string>(
-    state.event_days || '',
-    nums
-  );
+  const [days, setDays] = useState<string>(state.event_days || '');
 
   const filterAnnouncements = () => {
     action({
@@ -60,41 +75,24 @@ const FilterAnnouncement = ({ closeModal, action }: TFilterAnnouncement) => {
           <div className="mt-4">
             <BoldText>Announcement Type:</BoldText>
             <div className="mt-1">
-              <CustomField
-                onSelect={setType}
-                field="select"
+              <SelectField
+                list={types}
                 value={type}
-                placeholder="search..."
-              >
-                <CustomField.DropdownWrapper>
-                  {types.map((t) => (
-                    <CustomField.Dropdown key={t} value={t}>
-                      {capCharRemoveUnderscore(t)}
-                    </CustomField.Dropdown>
-                  ))}
-                </CustomField.DropdownWrapper>
-              </CustomField>
+                onSelect={setType}
+                dropdownElement={announcementTypeDropdown}
+              />
             </div>
           </div>
           <div className="mt-4">
-            <BoldText>Event days:</BoldText>
+            <BoldText>Event duration (days):</BoldText>
             <div className="mt-1">
-              <CustomField
-                field="input"
-                placeholder="Select event duration range..."
-                filterFn={daysListFilterFn}
-                onChange={setDays}
+              <SelectField
+                list={nums}
                 value={days}
-                icon="caretDown"
-              >
-                <CustomField.DropdownWrapper>
-                  {daysList.map((name) => (
-                    <CustomField.Dropdown key={name} value={name}>
-                      {name}
-                    </CustomField.Dropdown>
-                  ))}
-                </CustomField.DropdownWrapper>
-              </CustomField>
+                onSelect={setDays}
+                dropdownElement={eventDaysDropdown}
+                selectedElement={selectedEventDaysElement}
+              />
             </div>
           </div>
           <div className="my-4">

--- a/src/components/pages/Auth/Signup/index.tsx
+++ b/src/components/pages/Auth/Signup/index.tsx
@@ -79,7 +79,7 @@ const Signup = () => {
             {step > 1 ? (
               <button
                 onClick={() => {
-                  setSignupDetails({});
+                  setSignupDetails({ resetBulkState: true });
                   setStep(1);
                 }}
                 className="text-purple.dark text-sm font-semibold"

--- a/src/components/reusables/CustomField/SelectField/index.tsx
+++ b/src/components/reusables/CustomField/SelectField/index.tsx
@@ -2,9 +2,11 @@ import { memo, useEffect, useRef, useState } from 'react';
 import Icon from '~assets/Icons';
 import { Tag } from '~components/reusables/ui/Others';
 import DropdownWrapper from './DropdownWrapper';
+import { capCharRemoveUnderscore } from '~utils/format';
 
 type TSelectField = {
   dropdownElement?: (value: string | number) => JSX.Element;
+  selectedElement?: (value: string | number) => JSX.Element;
   width?: number;
   loading?: boolean;
   error?: string;
@@ -28,6 +30,7 @@ const SelectField = ({
   placeholder,
   list,
   dropdownElement,
+  selectedElement,
   onBlur,
   disabled,
 }: TSelectField) => {
@@ -51,17 +54,6 @@ const SelectField = ({
     }
   };
 
-  useEffect(() => {
-    document.addEventListener('click', toggleDropdown);
-    return () => {
-      document.removeEventListener('click', toggleDropdown);
-    };
-  }, [disabled]);
-
-  const emptyValue = (
-    <span className="text-gray-400">{placeholder || 'Select..'}</span>
-  );
-
   const handleSelect = (arg: string | number) => {
     if (multiselect) {
       const itemInState = value.find((item) => String(item) === String(arg));
@@ -76,6 +68,20 @@ const SelectField = ({
     (onSelect as (e: string | number) => void)(arg);
   };
 
+  useEffect(() => {
+    document.addEventListener('click', toggleDropdown);
+    return () => {
+      document.removeEventListener('click', toggleDropdown);
+    };
+  }, [disabled]);
+
+  const emptyValue = (
+    <span className="text-gray-400">{placeholder || 'Select..'}</span>
+  );
+
+  const cancelIcon = (
+    <Icon name="cancel" width={16} height={16} strokeWidth={2} />
+  );
   return (
     <div className="flex h-full relative" ref={elementRef}>
       <div
@@ -94,28 +100,29 @@ const SelectField = ({
           }`}
         >
           {multiselect &&
-            (value.length
-              ? value.map((prop) => (
-                  <Tag
-                    onClick={() => toggle && handleSelect(prop)}
-                    key={Math.random()}
-                  >
-                    <div className="flex items-center">
-                      <span className=" whitespace-nowrap pr-2">
-                        {String(prop).split('_').join(' ')}
-                      </span>
-                      <Icon
-                        name="cancel"
-                        width={16}
-                        height={16}
-                        strokeWidth={3}
-                      />
-                    </div>
-                  </Tag>
-                ))
-              : emptyValue)}
+            value.map((prop) =>
+              selectedElement ? (
+                <button className="flex items-center gap-1" key={prop}>
+                  {selectedElement?.(prop)} {cancelIcon}
+                </button>
+              ) : (
+                <Tag
+                  onClick={() => toggle && handleSelect(prop)}
+                  key={Math.random()}
+                >
+                  <div className="flex items-center">
+                    <span className=" whitespace-nowrap pr-2">
+                      {capCharRemoveUnderscore(String(prop))}
+                    </span>
+                    {cancelIcon}
+                  </div>
+                </Tag>
+              )
+            )}
 
-          {!multiselect && (String(value)?.split('_').join(' ') || emptyValue)}
+          {!multiselect && String(value).length
+            ? selectedElement?.(value) || capCharRemoveUnderscore(String(value))
+            : emptyValue}
         </div>
         <span className=" mr-1">
           <Icon height={20} width={20} name="caretDown" />

--- a/src/components/reusables/hooks/useBulkState.tsx
+++ b/src/components/reusables/hooks/useBulkState.tsx
@@ -1,8 +1,11 @@
 import { Dispatch, useReducer } from 'react';
 
-const useBulkState = <T,>(initialState: T): [T, Dispatch<Partial<T>>] => {
+const useBulkState = <T,>(
+  initialState: T
+): [T, Dispatch<Partial<T & { resetBulkState: true }>>] => {
   const [state, setState] = useReducer(
-    (state: T, newState: Partial<T>) => ({ ...state, ...newState }),
+    (state: T, newState: Partial<T>) =>
+      'resetBulkState' in newState ? ({} as T) : { ...state, ...newState },
     initialState
   );
 


### PR DESCRIPTION
# Why this PR?
- When a user signs up as a guardian and they opt to change the account midway, the input fields should reset

# What does this PR do?
- This PR fixes the above issue

# How to test your work?
- Sign up as a guardian,
- Go back midway using the select account option at the top
- All input field should be cleared if you select another account

# Pages to see your changes?
- /signup
